### PR TITLE
Add YouTube short embed below social media icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,6 +275,28 @@
       </div>
     </div>
   </section>
+
+  <!-- YouTube Short Video Section -->
+  <section class="py-16 bg-white dark:bg-gray-900">
+    <div class="max-w-4xl mx-auto px-4">
+      <div class="text-center space-y-6">
+        <h3 class="text-2xl font-bold text-gray-900 dark:text-white">See Our Space in Action</h3>
+        <p class="text-gray-600 dark:text-gray-400">Get a quick tour of Hibiscus Studio</p>
+
+        <!-- Video Container with Responsive Aspect Ratio -->
+        <div class="max-w-sm mx-auto">
+          <div class="media-container">
+            <iframe
+              src="https://www.youtube.com/embed/Qkyqb8bXjr0"
+              title="Hibiscus Studio Tour"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              allowfullscreen>
+            </iframe>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
       
       <!-- Studio Hire Options with Progressive Disclosure -->
       <div id="hire" class="text-center mt-12 space-y-8">


### PR DESCRIPTION
- Embedded YouTube short (Qkyqb8bXjr0) in new section below social media
- Uses existing .media-container class for responsive 9:16 aspect ratio
- Properly handles mobile and desktop screen sizes
- Maintains dark mode support and consistent styling
- Added descriptive heading and context text

🤖 Generated with [Claude Code](https://claude.com/claude-code)